### PR TITLE
Corrected widoco output folder

### DIFF
--- a/.github/workflows/cd_ghpages.yml
+++ b/.github/workflows/cd_ghpages.yml
@@ -68,7 +68,7 @@ jobs:
       run: |
         java -jar widoco-1.4.25-jar-with-dependencies_JDK-17.jar \
             -ontFile pink_annotation_schema.ttl \
-            -outFolder widoco \
+            -outFolder build/widoco \
             -getOntologyMetadata \
             -rewriteAll \
             -includeImportedOntologies \


### PR DESCRIPTION
The output must be in the build/ folder in order to be copied to github pages.