### PR TITLE
Generate keywords file from the turtle source

### DIFF
--- a/.github/workflows/cd_ghpages.yml
+++ b/.github/workflows/cd_ghpages.yml
@@ -91,8 +91,8 @@ jobs:
         keywords \
             --input=pink_annotation_schema.ttl \
             --context=build/context/pink_annotation_schema.jsonld \
-            --namespace-filter=pink \
             --redefine=allow
+            #--namespace-filter=pink
 
     - name: Generate keywords file
       run: |
@@ -100,8 +100,8 @@ jobs:
         keywords \
             --input=pink_annotation_schema.ttl \
             --yaml=build/context/keywords.yaml \
-            --namespace-filter=pink \
             --redefine=allow
+            #--namespace-filter=pink
 
     # - name: Create markdown documentation of keywords
     #   run: |


### PR DESCRIPTION
Generate json-ld context and keywords file. The generated files include the PINK Annotation Schema and all concepts it imports.

The generated files can be found here:
* keywords: https://pink-project.github.io/PINK-annotation-schema/context/keywords.yaml
* jsonld: https://pink-project.github.io/PINK-annotation-schema/context/pink_annotation_schema.jsonld

**Note**: Before merging to main, reset the `cd_ghpages.yml` workflow to only run on push to main.
