### PR TITLE
Changed the domain of hasModel to software

### DIFF
--- a/models.ttl
+++ b/models.ttl
@@ -74,7 +74,7 @@ widoco:introduction rdf:type owl:AnnotationProperty .
 #################################################################
 
 ###  https://w3id.org/pink#hasModel
-pink:implements rdf:type owl:ObjectProperty .
+pink:implementsModel rdf:type owl:ObjectProperty .
 
 
 ###  https://w3id.org/pink#hasParticipant
@@ -128,7 +128,7 @@ emmo:DataProcessing rdf:type owl:Class ;
 emmo:DataProcessingSoftware rdf:type owl:Class ;
                             rdfs:subClassOf pink:Software ,
                                             [ rdf:type owl:Restriction ;
-                                              owl:onProperty pink:implements ;
+                                              owl:onProperty pink:implementsModel ;
                                               owl:someValuesFrom emmo:MathematicalModel
                                             ] ;
                             skos:altLabel "DataProcessingApplication"@en ;

--- a/pink_annotation_schema.ttl
+++ b/pink_annotation_schema.ttl
@@ -440,9 +440,9 @@ vann:usageNote rdf:type owl:AnnotationProperty .
     rdfs:domain :Property ;
     rdfs:range prov:Entity .
 
-:implements rdf:type owl:ObjectProperty, owl:IrreflexiveProperty, owl:AsymmetricProperty ;
+:implementsModel rdf:type owl:ObjectProperty, owl:IrreflexiveProperty, owl:AsymmetricProperty ;
     rdfs:subPropertyOf :standsFor ;
-    skos:prefLabel "implements"@en ;
+    skos:prefLabel "implementsModel"@en ;
     rdfs:domain :Software ;
     rdfs:range :Model ;
     skos:definition "Relates a software to the model it implements."@en ;


### PR DESCRIPTION
The old description of `hasModel` didn't make sense, since activities doesn't implement models. Changed therefore the domain to software.

Also made hasModel a sub-property of `standsFor` based on a semiotic interpretation.

**Question**: Should we generalise the domain to  be any prov:Entity?
