### PR TITLE
Removed rdf:Property from reused terms

### DIFF
--- a/reused-terms.ttl
+++ b/reused-terms.ttl
@@ -316,7 +316,7 @@ dcat:keyword a owl:AnnotationProperty ;
     skos:definition "A keyword or tag describing the resource."@en ;
     rdfs:range rdf:langString .
 
-rdfs:label a rdf:Property ;
+rdfs:label a owl:AnnotationProperty ;
         rdfs:isDefinedBy <http://www.w3.org/2000/01/rdf-schema#> ;
         rdfs:label "label" ;
         rdfs:comment "A human-readable name for the subject." ;
@@ -329,27 +329,27 @@ dcterms:license a owl:ObjectProperty ;
     rdfs:domain dcat:Resource ;
     rdfs:range dcterms:LicenseDocument .
 
-skos:scopeNote a rdf:Property, owl:AnnotationProperty ;
+skos:scopeNote a owl:AnnotationProperty ;
     rdfs:label "scope note"@en ;
     rdfs:isDefinedBy <http://www.w3.org/2004/02/skos/core> ;
     rdfs:subPropertyOf skos:note ;
     skos:definition "A note that helps to clarify the meaning and/or the use of a concept."@en .
 
-rdfs:seeAlso a rdf:Property ;
+rdfs:seeAlso a owl:ObjectProperty ;
         rdfs:isDefinedBy <http://www.w3.org/2000/01/rdf-schema#> ;
         rdfs:label "seeAlso" ;
         rdfs:comment "Further information about the subject resource." ;
         rdfs:range rdfs:Resource ;
         rdfs:domain rdfs:Resource .
 
-rdfs:subClassOf a rdf:Property ;
+rdfs:subClassOf a owl:ObjectProperty ;
         rdfs:isDefinedBy <http://www.w3.org/2000/01/rdf-schema#> ;
         rdfs:label "subClassOf" ;
         rdfs:comment "The subject is a subclass of a class." ;
         rdfs:range rdfs:Class ;
         rdfs:domain rdfs:Class .
 
-dcat:theme a rdf:Property, owl:ObjectProperty ;
+dcat:theme a owl:ObjectProperty ;
   rdfs:comment "A main category of the resource. A resource can have multiple themes."@en ;
   rdfs:isDefinedBy <http://www.w3.org/TR/vocab-dcat/> ;
   rdfs:label "theme"@en ;


### PR DESCRIPTION
Replaced rdf:Prooperty with correct owl property in reused-terms.ttl
