### PR TITLE
Script for generating context for PINKKB using SPARQL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,9 @@ build/
 public/
 widoco/
 __pycache__/
+session_conf.yaml
 .venv
 .pdm-python
 pdm.lock
 widoco-*/
 widoco-1.4.25-jar-with-dependencies_JDK-17.jar
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ dlite-python>=0.5.49
 #python-dateutil
 pandas>=3.0.0
 pyshacl>=0.31.0
+keyring>=25.0.0

--- a/scripts/mkcontext.py
+++ b/scripts/mkcontext.py
@@ -41,7 +41,7 @@ outfile = outdir / "pinkkb.json"
 conffile = rootdir / "session_conf.yaml"
 
 # PINKKB doesn't contain the SSbD Core Ontology yet, so we can't test.
-# For now we therefore use MemDB and populate it manyally with SSbD core.
+# For now we therefore use MemDB and populate it manually with SSbD core.
 #session_name = "PINKKB"
 session_name = "MemDB"  # to be replaced with PINKKB
 

--- a/scripts/mkcontext.py
+++ b/scripts/mkcontext.py
@@ -1,0 +1,148 @@
+"""Script that generates a JSON-LD context for a knowledge base.
+
+The knowledge base must have a SPARQL endpoint supported by Tripper
+(typically via the sparqlwrapper plugin).
+
+Before running this script, you must create a session configuration
+file named `session_conf.yaml` in the root directory.
+This file should have the following content:
+
+    PINKKB:
+      backend: sparqlwrapper
+      base_iri: https://graphdb.pink-project.eu/repositories/testing
+      update_iri: https://graphdb.pink-project.eu/repositories/testing/statements
+      check_url: https://graphdb.pink-project.eu/repositories
+      username: jesper-friis
+      password: KEYRING
+
+    MemDB:
+      backend: rdflib
+
+Please replace the PINKKB username `jesper-friis` with your username.
+
+Set the password by running
+
+    keyring set PINKKB <my_password>
+
+See https://emmc-asbl.github.io/tripper/latest/session/ for details.
+
+"""
+import json
+from pathlib import Path
+
+from tripper import RDF, RDFS, SKOS, Session, Triplestore
+from tripper.utils import prefix_iri
+
+
+rootdir = Path(__file__).resolve().parent.parent
+outdir = rootdir / "jsonld"
+outfile = outdir / "pinkkb.json"
+conffile = rootdir / "session_conf.yaml"
+
+# PINKKB doesn't contain the SSbD Core Ontology yet, so we can't test.
+# For now we therefore use MemDB and populate it manyally with SSbD core.
+#session_name = "PINKKB"
+session_name = "MemDB"  # to be replaced with PINKKB
+
+session = Session(conffile)
+ts = session.get_triplestore(session_name)
+
+# Populate MemDB manually
+if session_name == "MemDB":
+    ts.parse("https://w3id.org/ssbd")
+
+# Define prefixes
+ts.bind("bibo", "http://purl.org/ontology/bibo/")
+ts.bind("chemowl", "http://www.semanticweb.org/ontologies/cheminf.owl#")
+ts.bind("dcat", "http://www.w3.org/ns/dcat#")
+ts.bind("dcatap", "http://data.europa.eu/r5r/")
+ts.bind("dcterms", "http://purl.org/dc/terms/")
+ts.bind("ddoc", "https://w3id.org/emmo/application/datadoc#")
+ts.bind("foaf", "http://xmlns.com/foaf/0.1/")
+ts.bind("obo", "http://purl.obolibrary.org/obo/")
+ts.bind("oboowl", "http://www.geneontology.org/formats/oboInOwl#")
+ts.bind("owl", "http://www.w3.org/2002/07/owl#")
+ts.bind("prov", "http://www.w3.org/ns/prov#")
+ts.bind("rdf", "http://www.w3.org/1999/02/22-rdf-syntax-ns#")
+ts.bind("rdfs", "http://www.w3.org/2000/01/rdf-schema#")
+ts.bind("skos", "http://www.w3.org/2004/02/skos/core#")
+ts.bind("ssbd", "https://w3id.org/ssbd/")
+ts.bind("swrl", "http://www.w3.org/2003/11/swrl#")
+ts.bind("vann", "http://purl.org/vocab/vann/")
+ts.bind("widoco", "https://w3id.org/widoco/vocab#")
+ts.bind("xsd", "http://www.w3.org/2001/XMLSchema#")
+
+
+# Help functions
+
+def add(ctx, triples, prefixes, type=None):
+    """Add `triples` to the context `ctx`."""
+    labels = {s: str(o) for s, p, o in triples if p == SKOS.prefLabel}
+    ranges = {s: o for s, p, o in triples if p == RDFS.range}
+    for iri, label in labels.items():
+        ctx[label] = {
+            "@id": prefix_iri(iri, prefixes),
+            "@type": type if type else prefix_iri(ranges[iri], prefixes),
+        }
+
+
+def get_query(target, prefixes, isprop=True):
+    """Return SPARQL query for given target.
+
+    `target` should be one of:
+      - "owl:AnnotationProperty"
+      - "owl:ObjectProperty"
+      - "owl:DatatypeProperty"
+      - "owl:Class"
+    """
+    pf = [f"PREFIX {prefix}: <{ns}>" for prefix, ns in prefixes.items()]
+    range = "?prop rdfs:range ?range ." if isprop else ""
+    return "\n".join(pf) + "\n" + f"""
+CONSTRUCT {{
+  ?prop a {target} ;
+    skos:prefLabel ?label .
+  {range}
+}}
+WHERE {{
+  ?prop a {target} .
+  {range}
+  OPTIONAL {{
+    {{
+      ?prop skos:prefLabel ?label
+    }} UNION {{
+      ?prop rdfs:label ?label
+    }} .
+  }}
+}}
+"""
+
+
+# Prepare the context
+ctx = {"@version": 1.1}  # Inner context
+context = {"@context": ctx}  # Full context
+
+# Add prefixes to context
+prefixes = {prefix: str(ns) for prefix, ns in ts.namespaces.items()}
+for prefix in sorted(prefixes):
+    ctx[prefix] = prefixes[prefix]
+
+# Populate the context
+q1 = get_query("owl:AnnotationProperty", prefixes)
+q2 = get_query("owl:ObjectProperty", prefixes)
+q3 = get_query("owl:DatatypeProperty", prefixes)
+q4 = get_query("owl:Class", prefixes, isprop=False)
+r1 = list(ts.query(q1))
+r2 = list(ts.query(q2))
+r3 = list(ts.query(q3))
+r4 = list(ts.query(q4))
+add(ctx, r1, prefixes)
+add(ctx, r2, prefixes, "@id")
+add(ctx, r3, prefixes)
+add(ctx, r4, prefixes, "owl:Class")
+
+# Write context to file
+outdir.mkdir(exist_ok=True)
+with open(outfile, "wt", encoding="utf-8") as f:
+    json.dump(context, f, indent=2)
+
+print(outfile.read_text())

--- a/scripts/mkcontext.py
+++ b/scripts/mkcontext.py
@@ -30,8 +30,9 @@ See https://emmc-asbl.github.io/tripper/latest/session/ for details.
 import json
 from pathlib import Path
 
-from tripper import RDF, RDFS, SKOS, Session, Triplestore
+from tripper import OWL, RDF, RDFS, SKOS, Session, Triplestore
 from tripper.utils import prefix_iri
+from tripper.datadoc.utils import iriname
 
 
 rootdir = Path(__file__).resolve().parent.parent
@@ -79,48 +80,6 @@ prefixes = {
 for prefix, ns in prefixes.items():
     ts.bind(prefix, ns)
 
-
-# Help functions
-
-def add(ctx, triples, prefixes, type=None):
-    """Add `triples` to the context `ctx`."""
-    iris = set(s for s, p, o in triples)
-    labels = {s: str(o) for s, p, o in triples if p == SKOS.prefLabel}
-    ranges = {s: o for s, p, o in triples if p == RDFS.range}
-    for iri in iris:
-        prefixed = prefix_iri(iri, prefixes)
-        key = labels[iri] if iri in labels else prefixed
-        ctx[key] = {
-            "@id": prefixed,
-            "@type": type if type else prefix_iri(ranges[iri], prefixes),
-        }
-
-
-def get_query(target, prefixes, isprop=True):
-    """Return SPARQL query for given target.
-
-    `target` should be one of:
-      - "owl:AnnotationProperty"
-      - "owl:ObjectProperty"
-      - "owl:DatatypeProperty"
-      - "owl:Class"
-    """
-    pf = [f"PREFIX {prefix}: <{ns}>" for prefix, ns in prefixes.items()]
-    range = "?prop rdfs:range ?range ." if isprop else ""
-    return "\n".join(pf) + "\n" + f"""
-CONSTRUCT {{
-  ?prop a {target} ;
-    skos:prefLabel ?prefLabel .
-  {range}
-}}
-WHERE {{
-  ?prop a {target} .
-  {range}
-  OPTIONAL {{ ?prop skos:prefLabel ?prefLabel }}
-}}
-"""
-
-
 # Prepare the context
 ctx = {"@version": 1.1}  # Inner context
 context = {"@context": ctx}  # Full context
@@ -129,23 +88,58 @@ context = {"@context": ctx}  # Full context
 for prefix in sorted(prefixes):
     ctx[prefix] = prefixes[prefix]
 
-# Populate the context
-q1 = get_query("owl:AnnotationProperty", prefixes)
-q2 = get_query("owl:ObjectProperty", prefixes)
-q3 = get_query("owl:DatatypeProperty", prefixes)
-q4 = get_query("owl:Class", prefixes, isprop=False)
-r1 = list(ts.query(q1))
-r2 = list(ts.query(q2))
-r3 = list(ts.query(q3))
-r4 = list(ts.query(q4))
-add(ctx, r1, prefixes)
-add(ctx, r2, prefixes, "@id")
-add(ctx, r3, prefixes)
-add(ctx, r4, prefixes, "owl:Class")
+
+# Execute SPARQL query + workaround bug that None is returned as "None"
+q = """
+SELECT ?iri ?prefLabel ?type ?range
+WHERE {
+  ?iri a ?type .
+  OPTIONAL { ?iri rdfs:range ?range } .
+  OPTIONAL { ?iri skos:prefLabel ?prefLabel } .
+  VALUES ?type { owl:AnnotationProperty owl:ObjectProperty owl:DatatypeProperty owl:Class }
+}
+"""
+r = [[x if x and x != "None" else None for x in t] for t in ts.query(q)]
+
+prefixed = {iri: prefix_iri(iri, prefixes) for iri, _, _, _ in r}
+keys = {}
+for iri, prefLabel, _, _ in r:
+    if prefLabel:
+        keys[iri] = str(prefLabel)
+    else:
+        name = iriname(iri)
+        keys[iri] = prefixed[iri] if name in keys else name
+ranges = {iri: prefix_iri(range, prefixes) for iri, _, _, range in r if range}
+results = [  # New sorted result list
+    (keys[iri], iri, type)
+    for iri, _, type, _ in sorted(r, key=lambda x: keys[x[0]])
+]
+
+# Add annotation properties to context
+for key, iri, type in results:
+    if type == OWL.AnnotationProperty:
+        pf = prefixed[iri]
+        ctx[key] = {"@id": pf, "@type": ranges[iri]} if iri in ranges else pf
+
+# Add object properties to context
+for key, iri, type in results:
+    if type == OWL.ObjectProperty:
+        ctx[key] = {"@id": prefixed[iri], "@type": "@id"}
+
+# Add data properties to context
+for key, iri, type in results:
+    if type == OWL.DatatypeProperty:
+        pf = prefixed[iri]
+        ctx[key] = {"@id": pf, "@type": ranges[iri]} if iri in ranges else pf
+
+# Add classes to context
+for key, iri, type in results:
+    if type == OWL.Class:
+        ctx[keys[iri]] = {"@id": prefixed[iri], "@type": "owl:Class"}
 
 # Write context to file
 outdir.mkdir(exist_ok=True)
 with open(outfile, "wt", encoding="utf-8") as f:
     json.dump(context, f, indent=2)
 
-#print(outfile.read_text())
+print(outfile.read_text())

--- a/scripts/mkcontext.py
+++ b/scripts/mkcontext.py
@@ -103,12 +103,20 @@ r = [[x if x and x != "None" else None for x in t] for t in ts.query(q)]
 
 prefixed = {iri: prefix_iri(iri, prefixes) for iri, _, _, _ in r}
 keys = {}
+used_keys = {}
+
 for iri, prefLabel, _, _ in r:
     if prefLabel:
-        keys[iri] = str(prefLabel)
+        key = str(prefLabel)
     else:
         name = iriname(iri)
-        keys[iri] = prefixed[iri] if name in keys else name
+        key = prefixed[iri] if name in used_keys else name
+
+    if key in used_keys:
+        raise ValueError(f"Duplicate context key {key!r}: {used_keys[key]} and {iri}")
+
+    keys[iri] = key
+    used_keys[key] = iri
 ranges = {iri: prefix_iri(range, prefixes) for iri, _, _, range in r if range}
 results = [  # New sorted result list
     (keys[iri], iri, type)

--- a/scripts/mkcontext.py
+++ b/scripts/mkcontext.py
@@ -32,6 +32,7 @@ from pathlib import Path
 
 from tripper import RDF, RDFS, SKOS, Session, Triplestore
 from tripper.utils import prefix_iri
+from tripper.datadoc.utils import iriname
 
 
 rootdir = Path(__file__).resolve().parent.parent
@@ -77,10 +78,12 @@ ts.bind("xsd", "http://www.w3.org/2001/XMLSchema#")
 
 def add(ctx, triples, prefixes, type=None):
     """Add `triples` to the context `ctx`."""
+    iris = set(s for s, p, o in triples)
     labels = {s: str(o) for s, p, o in triples if p == SKOS.prefLabel}
     ranges = {s: o for s, p, o in triples if p == RDFS.range}
-    for iri, label in labels.items():
-        ctx[label] = {
+    for iri in iris:
+        key = labels[iri] if iri in labels else iriname(iri)
+        ctx[key] = {
             "@id": prefix_iri(iri, prefixes),
             "@type": type if type else prefix_iri(ranges[iri], prefixes),
         }

--- a/scripts/mkcontext.py
+++ b/scripts/mkcontext.py
@@ -52,25 +52,32 @@ if session_name == "MemDB":
     ts.parse("https://w3id.org/ssbd")
 
 # Define prefixes
-ts.bind("bibo", "http://purl.org/ontology/bibo/")
-ts.bind("chemowl", "http://www.semanticweb.org/ontologies/cheminf.owl#")
-ts.bind("dcat", "http://www.w3.org/ns/dcat#")
-ts.bind("dcatap", "http://data.europa.eu/r5r/")
-ts.bind("dcterms", "http://purl.org/dc/terms/")
-ts.bind("ddoc", "https://w3id.org/emmo/application/datadoc#")
-ts.bind("foaf", "http://xmlns.com/foaf/0.1/")
-ts.bind("obo", "http://purl.obolibrary.org/obo/")
-ts.bind("oboowl", "http://www.geneontology.org/formats/oboInOwl#")
-ts.bind("owl", "http://www.w3.org/2002/07/owl#")
-ts.bind("prov", "http://www.w3.org/ns/prov#")
-ts.bind("rdf", "http://www.w3.org/1999/02/22-rdf-syntax-ns#")
-ts.bind("rdfs", "http://www.w3.org/2000/01/rdf-schema#")
-ts.bind("skos", "http://www.w3.org/2004/02/skos/core#")
-ts.bind("ssbd", "https://w3id.org/ssbd/")
-ts.bind("swrl", "http://www.w3.org/2003/11/swrl#")
-ts.bind("vann", "http://purl.org/vocab/vann/")
-ts.bind("widoco", "https://w3id.org/widoco/vocab#")
-ts.bind("xsd", "http://www.w3.org/2001/XMLSchema#")
+prefixes = {
+    "bibo": "http://purl.org/ontology/bibo/",
+    "cheminf": "http://semanticscience.org/resource/",
+    "chemowl": "http://www.semanticweb.org/ontologies/cheminf.owl#",
+    "dcat": "http://www.w3.org/ns/dcat#",
+    "dcatap": "http://data.europa.eu/r5r/",
+    "dcterms": "http://purl.org/dc/terms/",
+    "ddoc": "https://w3id.org/emmo/application/datadoc#",
+    "dm": "https://w3id.org/emmo/domain/datamodel#",
+    "emmo": "https://w3id.org/emmo/hume#",
+    "foaf": "http://xmlns.com/foaf/0.1/",
+    "obo": "http://purl.obolibrary.org/obo/",
+    "oboowl": "http://www.geneontology.org/formats/oboInOwl#",
+    "owl": "http://www.w3.org/2002/07/owl#",
+    "prov": "http://www.w3.org/ns/prov#",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "ssbd": "https://w3id.org/ssbd/",
+    "swrl": "http://www.w3.org/2003/11/swrl#",
+    "vann": "http://purl.org/vocab/vann/",
+    "widoco": "https://w3id.org/widoco/vocab#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+}
+for prefix, ns in prefixes.items():
+    ts.bind(prefix, ns)
 
 
 # Help functions
@@ -119,7 +126,6 @@ ctx = {"@version": 1.1}  # Inner context
 context = {"@context": ctx}  # Full context
 
 # Add prefixes to context
-prefixes = {prefix: str(ns) for prefix, ns in ts.namespaces.items()}
 for prefix in sorted(prefixes):
     ctx[prefix] = prefixes[prefix]
 
@@ -142,4 +148,4 @@ outdir.mkdir(exist_ok=True)
 with open(outfile, "wt", encoding="utf-8") as f:
     json.dump(context, f, indent=2)
 
-print(outfile.read_text())
+#print(outfile.read_text())

--- a/scripts/mkcontext.py
+++ b/scripts/mkcontext.py
@@ -32,7 +32,6 @@ from pathlib import Path
 
 from tripper import RDF, RDFS, SKOS, Session, Triplestore
 from tripper.utils import prefix_iri
-from tripper.datadoc.utils import iriname
 
 
 rootdir = Path(__file__).resolve().parent.parent
@@ -82,9 +81,10 @@ def add(ctx, triples, prefixes, type=None):
     labels = {s: str(o) for s, p, o in triples if p == SKOS.prefLabel}
     ranges = {s: o for s, p, o in triples if p == RDFS.range}
     for iri in iris:
-        key = labels[iri] if iri in labels else iriname(iri)
+        prefixed = prefix_iri(iri, prefixes)
+        key = labels[iri] if iri in labels else prefixed
         ctx[key] = {
-            "@id": prefix_iri(iri, prefixes),
+            "@id": prefixed,
             "@type": type if type else prefix_iri(ranges[iri], prefixes),
         }
 
@@ -103,19 +103,13 @@ def get_query(target, prefixes, isprop=True):
     return "\n".join(pf) + "\n" + f"""
 CONSTRUCT {{
   ?prop a {target} ;
-    skos:prefLabel ?label .
+    skos:prefLabel ?prefLabel .
   {range}
 }}
 WHERE {{
   ?prop a {target} .
   {range}
-  OPTIONAL {{
-    {{
-      ?prop skos:prefLabel ?label
-    }} UNION {{
-      ?prop rdfs:label ?label
-    }} .
-  }}
+  OPTIONAL {{ ?prop skos:prefLabel ?prefLabel }}
 }}
 """
 

--- a/scripts/mkcontext.py
+++ b/scripts/mkcontext.py
@@ -142,4 +142,4 @@ outdir.mkdir(exist_ok=True)
 with open(outfile, "wt", encoding="utf-8") as f:
     json.dump(context, f, indent=2)
 
-print(outfile.read_text())
+#print(outfile.read_text())


### PR DESCRIPTION
This could in principle also have been done with Ontokit. However, since Ontokit doesn't have a SPARQL you would first have to serialise the whole PINK KB (which with time might be huge) to turtle and then load it with Ontokit. 

This script generates the context from a single SPARQL query.

> [!Note] 
> In production, set `session_name = "PINKKB"`. 
>
> However, since PINKKB currently isn't populated with the SSbD Core Ontology, we have for now `session_name = "MemDB"`, which loads the SSbD Core Ontology into an in-memory triplestore. 

If you like the script, we could consider to generalise it and move it into tripper. 